### PR TITLE
Update PyPI publish action to use release version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -65,6 +65,6 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for publishing Python packages. The change updates the action used to publish release distributions to PyPI to use a more specific version reference.

* Updated the `Publish release distributions to PyPI` step in `.github/workflows/python-publish.yml` to use `pypa/gh-action-pypi-publish@release/v1` instead of `@v1`.