### PR TITLE
Fix PyPI package import issues and improve .gitignore for v2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,100 @@
 .github\instructions\codacy.instructions.md
 codacy-fixes.txt.applied
 
-# Python cache files
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
 *.pyc
 *.pyo
 *.pyd
-.Python
+
+# C extensions
 *.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Virtual environments
+.env
+.env.local
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Temporary files
+*.tmp
+*.temp
+temp/
+tmp/
 


### PR DESCRIPTION
## 🛠️ PyPI Package Import Fix for v2.0.2

### 🎯 **Problem Addressed**
The PyPI package v2.0.1 has critical import issues preventing the command-line tool from working:
```
Error: Failed to import DinoScan modules: No module named 'analyzers'
```

### ✅ **Testing Results**
**Local DinoScan works perfectly** - comprehensive testing shows:
- ✅ **Security Analysis**: Detected unsafe pickle deserialization, hardcoded secrets, weak crypto
- ✅ **Duplicate Code Detection**: Found exact and structural duplicates with similarity scores  
- ✅ **Documentation Analysis**: Identified missing docstrings and parameter documentation
- ✅ **All Analyzers Functional**: security, duplicates, docs, circular, dead-code analyzers working

### 🔧 **Changes Made**

#### **Version Bump**
- Bumped version from `2.0.1` → `2.0.2` in `pyproject.toml`
- Prepares for new PyPI release with import fixes

#### **Enhanced .gitignore**
- Added comprehensive Python development patterns
- Proper `__pycache__/` and compiled Python file exclusions
- Virtual environments, IDE files, OS files, temp files
- Prevents accidental commits of generated files

### 🚀 **Expected Outcome**
- New PyPI v2.0.2 release will include all CodeTokenizer import fixes
- Command-line `dinoscan --version` will work properly
- All DinoScan analyzers will be accessible via PyPI package

### 🧪 **Validation Required**
After merge and PyPI release:
1. Install: `pip install dinoscan==2.0.2`
2. Test: `dinoscan --version` (should work without import errors)
3. Verify: `dinoscan security test_file.py` (should detect issues)

### 📋 **Files Changed**
- `pyproject.toml` - Version bump to 2.0.2
- `.gitignore` - Enhanced with comprehensive Python patterns