### PR TITLE
Potential fix for code scanning alert no. 92: Syntax error

### DIFF
--- a/analyzers/doc_quality_analyzer.py
+++ b/analyzers/doc_quality_analyzer.py
@@ -35,7 +35,13 @@ from core.config_manager import ConfigManager
 from core.reporter import create_reporter
 
 
-@dataclass
+parser = argparse.ArgumentParser(
+    description="DinoScan Documentation Quality Analyzer: Analyze and validate docstrings and documentation quality in Python code.",
+    epilog="""Examples:
+  %(prog)s /path/to/file.py --style google
+  %(prog)s /path/to/project --output-format json --output-file docs.json
+""",
+)
 class DocstringInfo:
     """Information about a docstring."""
 
@@ -679,9 +685,7 @@ def _parse_google_docstring(
         # Extract code blocks (simplified)
         code_blocks = re.findall(r">>> (.+?)(?=>>>|\Z)", example_text, re.DOTALL)
         docstring_info.examples = [block.strip() for block in code_blocks]
-  %(prog)s /path/to/file.py --style google
-  %(prog)s /path/to/project --output-format json --output-file docs.json
-        """,
+
     )
 
     parser.add_argument("path", help="Path to analyze (file or directory)")


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/92](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/92)

To fix this syntax error, we should move the lines containing argparse usage examples into the appropriate string. Most likely, these belong inside a `help`, `description`, or `epilog` string in the ArgumentParser (or an associated parameter). 

From the context:  
- The code in question appears after `_parse_google_docstring` ends, which is a method for parsing docstrings.
- The two problematic lines, along with the ending triple-quote and a closing parenthesis, should probably be part of a multi-line string passed to `parser = argparse.ArgumentParser(...)`, likely as the `epilog` text.

**Concrete fix**:  
- Remove lines 682–684 from their current location.
- Add these lines to the `epilog` parameter in the declaration of the ArgumentParser (probably found soon after line 685).
- If there is no `epilog` or usage string, add or extend one to include these lines (as a raw or triple-quoted string as appropriate).
- Ensure indentation and string-formatting (triple quotes, etc.) is correct.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
