### PR TITLE
Potential fix for code scanning alert no. 93: Empty except

### DIFF
--- a/analyzers/circular_import_analyzer.py
+++ b/analyzers/circular_import_analyzer.py
@@ -25,6 +25,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+import logging
 
 from core.base_analyzer import ASTAnalyzer, Category, Finding, Severity
 from core.config_manager import ConfigManager
@@ -381,8 +382,8 @@ class CircularImportAnalyzer(ASTAnalyzer):
                 lines = f.readlines()
                 if 1 <= line_number <= len(lines):
                     return lines[line_number - 1].strip()
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning("Failed to get import context from '%s' (line %d): %s", module_info.file_path, line_number, e)
 
         return ""
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/93](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/93)

The best fix is to replace the empty `except Exception: pass` block with a version that logs the exception, so that failures to read the file or extract context lines are visible while not interrupting program flow. Since there is no custom logging visible in the snippet, the minimal, least-intrusive fix is to use the standard library's `logging` module, adding an `import logging` at the top of the file (if not already present in earlier shown code). The except block should then include a log statement (ideally at DEBUG or WARNING level, possibly including filename and line number attempted).

Changes required:
- At the top of the file, add `import logging`.
- Replace the `except Exception: pass` block with logging:  
  `logging.warning(...)` (or `.debug(...)`) including relevant file and line info.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Log exceptions in circular import analyzer when failing to read file context instead of silently swallowing errors to address code scanning alert

Bug Fixes:
- Replace empty except block with a warning log that includes file path, line number, and exception details

Enhancements:
- Add import logging to enable warning messages