### PR TITLE
Potential fix for code scanning alert no. 95: Syntax error

### DIFF
--- a/analyzers/doc_quality_analyzer.py
+++ b/analyzers/doc_quality_analyzer.py
@@ -685,7 +685,6 @@ def _parse_google_docstring(
         code_blocks = re.findall(r">>> (.+?)(?=>>>|\Z)", example_text, re.DOTALL)
         docstring_info.examples = [block.strip() for block in code_blocks]
 
-    )
 
     parser.add_argument("path", help="Path to analyze (file or directory)")
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/95](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/95)

To fix the syntax error, simply delete the stray closing parenthesis `)` at line 688 in `analyzers/doc_quality_analyzer.py`. This line does not belong to any expression and is not balancing an opening `(`, so its removal has no side effect on the rest of the code. Ensure that no other parenthetical mismatch remains in the surrounding region; review context before and after the removal to confirm. No other fix or modification is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
