### PR TITLE
Potential fix for code scanning alert no. 97: Syntax error

### DIFF
--- a/analyzers/doc_quality_analyzer.py
+++ b/analyzers/doc_quality_analyzer.py
@@ -673,7 +673,6 @@ def parse_numpy_docstring(self, content: str, docstring_info: DocstringInfo) -> 
 def parse_sphinx_docstring(self, content: str, docstring_info: DocstringInfo) -> None:
     return self._parse_sphinx_docstring(content, docstring_info)
         help="Skip example validation",
-    )
 
     parser.add_argument(
         "--verbose",


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/97](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/97)

To fix the problem:
- Remove the extraneous closing parenthesis at line 676.
- This line is not needed syntactically; its presence results in a syntax error when executing or importing the module.
- No other lines, imports, or functional code need to be added or changed; simply delete this lone line.  
- No follow-up method, import, or variable definitions are needed; the fix is surgical and limited to deleting one line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
