### PR TITLE
Potential fix for code scanning alert no. 192: Unreachable code

### DIFF
--- a/analyzers/dead_code_analyzer.py
+++ b/analyzers/dead_code_analyzer.py
@@ -307,7 +307,6 @@ def is_meaningful_usage(self, usage, symbol: Symbol) -> bool:
     """Return True if a usage in the same file is considered meaningful beyond definition."""
     return self._is_meaningful_usage(usage, symbol)
     # Public if not private and at module level
-    return not symbol.is_private and symbol.scope == "module"
 
 
 def get_removal_suggestion(self, symbol: Symbol):


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/192](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/192)

To fix the unreachable code, the best approach is to delete the unreachable return statement: `return not symbol.is_private and symbol.scope == "module"` on line 310. This can be safely done because, as currently written, it can never be reached, and its removal will not alter the behavior of the function. The rest of the function will remain unchanged, and removing the dead code improves clarity and maintainability.

Specifically:
- Edit the function `is_meaningful_usage` in `analyzers/dead_code_analyzer.py`.
- Remove the line `return not symbol.is_private and symbol.scope == "module"` at line 310.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
