### PR TITLE
Potential fix for code scanning alert no. 190: Variable defined multiple times

### DIFF
--- a/analyzers/dead_code_analyzer.py
+++ b/analyzers/dead_code_analyzer.py
@@ -240,12 +240,6 @@ def is_dead_symbol(self, symbol) -> bool:
     """Return True if the given symbol is dead; otherwise False."""
     return self._is_dead_symbol(symbol)
 
-def create_dead_code_finding(self, symbol) -> Finding | None:
-    """Create a Finding object for the given symbol if it is dead; otherwise return None."""
-    if not self.is_dead_symbol(symbol):
-        return None
-    return self._create_dead_code_finding(symbol)
-
 
 def _analyze_dead_code(self) -> list[Finding]:
     """Analyze collected symbols and usages to find dead code."""


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/190](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/190)

To fix the problem, the redundant first definition of `create_dead_code_finding` (lines 243 to 248) should be deleted from analyzers/dead_code_analyzer.py. The function is immediately redefined later on (line 317), and the first definition is never used, so there is no danger in removing it. No further changes or imports are necessary, as this is only the removal of a duplicate/redundant function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
