### PR TITLE
Potential fix for code scanning alert no. 191: Unused import

### DIFF
--- a/analyzers/dead_code_analyzer.py
+++ b/analyzers/dead_code_analyzer.py
@@ -21,7 +21,6 @@ import argparse
 import ast
 import builtins
 import os
-import re
 import sys
 import traceback
 from collections import defaultdict


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/191](https://github.com/Dino-Pit-Studios/DinoScan/security/code-scanning/191)

To fix the unused import warning, the `import re` statement on line 24 should be removed from `analyzers/dead_code_analyzer.py`. This change should not affect existing functionality, as no references to `re` are present in the code shown. Only the single import line needs to be deleted; no other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unused `re` import from dead code analyzer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dead_code_analyzer.py"] -- "remove unused import" --> B["cleaned imports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dead_code_analyzer.py</strong><dd><code>Remove unused re import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

analyzers/dead_code_analyzer.py

- Remove unused `import re` statement from line 24


</details>


  </td>
  <td><a href="https://github.com/Dino-Pit-Studios/DinoScan/pull/72/files#diff-041bdd5b41554004cd11258cfed1ca6764de0dcf54ad7a90d54b0dfe013ad6c8">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Bug Fixes:
- Remove the unused `import re` statement from analyzers/dead_code_analyzer.py